### PR TITLE
Remove deprecated asyncio coroutine decorator, handle session closing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,10 @@ setup(name='pyfido',
       install_requires=install_requires,
       tests_require=tests_require,
       classifiers=[
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
       ],
 )


### PR DESCRIPTION
This PR fixes #3, by converting the old `@asyncio.coroutine`/`yield from` syntax to the new Python async/await syntax introduced in Python 3.5.

This removes Python 3.4 compatibility but prepares for Python 3.10. I've adjusted the package classifiers to match that.

Additionally, added a small change that would not close a passed session. Only self-created sessions should be cleaned up/closed. This prevents the accidental closing of sessions not managed by this package.

⚠️ I don't have access to an account for testing and thus need verification.